### PR TITLE
Await till csv write is complete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "growwapi",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "growwapi",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "camelcase-keys": "^9.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "growwapi",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "NodeJS SDK for Groww trading APIs",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/utils/fileCache.ts
+++ b/src/utils/fileCache.ts
@@ -47,13 +47,25 @@ async function downloadCSVToFile(url: string, filePath: string): Promise<void> {
   const writer = fs.createWriteStream(filePath);
   const reader = response.body.getReader();
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    writer.write(Buffer.from(value));
-  }
+  return new Promise((resolve, reject) => {
+    writer.on('finish', resolve);
+    writer.on('error', reject);
 
-  writer.end();
+    (async () => {
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done)
+            break;
+          writer.write(Buffer.from(value));
+        }
+        writer.end();
+      } catch (error) {
+        writer.destroy();
+        reject(error);
+      }
+    })();
+  });
 }
 
 export async function fetchCSV(url: string, ttl: number = FILECACHE_TTL): Promise<CachedCSVResult> {


### PR DESCRIPTION
This pull request improves the error handling and flow control in the `downloadCSVToFile` function in `src/utils/fileCache.ts`. The key change ensures that the file-writing process is properly managed with a Promise, handling both success and failure cases more robustly.

### Improvements to error handling and flow control:
* Refactored `downloadCSVToFile` to wrap the file-writing process in a Promise. This ensures that the `finish` and `error` events from the `writer` are handled correctly. The `writer` is now explicitly destroyed in the event of an error to prevent resource leaks.