### PR TITLE
Add provenance to publish npm package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,6 +29,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build
-      - run: npm publish
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
This pull request updates the npm publish step in the GitHub Actions workflow to improve package publishing security and accessibility.

NPM publish workflow improvements:

* [`.github/workflows/npm-publish.yml`](diffhunk://#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L32-R32): Adds the `--provenance` flag to the `npm publish` command to include provenance information and sets `--access public` to explicitly publish the package publicly.